### PR TITLE
Add catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,7 +2,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: offline-pep
-  description: Auto-generated catalog-info.yaml.
+  description: offline-pep
   tags:
   - go
   - vue

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: offline-pep
+  description: Auto-generated catalog-info.yaml.
+  tags:
+  - go
+  - vue
+  - javascript
+  - makefile
+  - shell
+  - dockerfile
+  - batchfile
+  - scss
+spec:
+  type: unknown
+  owner: group:possible-orphan
+  lifecycle: unknown


### PR DESCRIPTION
This PR adds a `catalog-info.yaml` file to Backstage when merged. If your repo is GitHub Only, this will not be picked up Backstage presently.